### PR TITLE
Use new API version for product details

### DIFF
--- a/supermarktconnector/ah.py
+++ b/supermarktconnector/ah.py
@@ -61,7 +61,7 @@ class AHConnector:
         """
         product_id = product if not isinstance(product, dict) else product['webshopId']
         response = requests.get(
-            'https://ms.ah.nl/mobile-services/product/detail/v3/fir/{}'.format(product_id),
+            'https://ms.ah.nl/mobile-services/product/detail/v4/fir/{}'.format(product_id),
             headers={**HEADERS, "Authorization": "Bearer {}".format(self._access_token.get('access_token'))}
         )
         if not response.ok:


### PR DESCRIPTION
This PR fixes #13 by "upgrading" to the new version of the AH "API". v3 no longer returned correct results, v4 does. I cannot confirm whether the result format is the same so this may be a breaking change.