### PR TITLE
Add get_product_category_details for AH

### DIFF
--- a/supermarktconnector/ah.py
+++ b/supermarktconnector/ah.py
@@ -93,22 +93,26 @@ class AHConnector:
         return response.json()
 
     
-    def get_product_category_details(self, product_details):
+    def get_product_category_details(self, product_details, brand=None):
         """
         Get advanced details of the categories of a product
         :param product_details: Product details object (dict) as returned by get_product_details or the taxonomy ID
+        :param brand: Brand abbreviation of the product (str). Only needed if passing the taxonomy ID directly instead of the product details object for product_details
         :return: dict containing category information
         """
-        if not isinstance(product_details, dict):
+        if not isinstance(product_details, dict) and brand is not None:
             taxonomy_id = product_details
         else:
             taxonomy_id = product_details['productCard']['subCategoryId']
+            brand = product_details['productCard']['brand']
         response = requests.get(
-            f'https://www.ah.nl/zoeken/api/products/taxonomy-brand?taxonomyId={taxonomy_id}'
+            'https://www.ah.nl/zoeken/api/products/taxonomy-brand?brand={}&taxonomyId={}'.format(brand, taxonomy_id),
+            headers={**HEADERS}
         )
         if not response.ok:
             response.raise_for_status()
         return response.json()
+    
 
     def get_bonus_periods(self):
         """

--- a/supermarktconnector/ah.py
+++ b/supermarktconnector/ah.py
@@ -92,6 +92,24 @@ class AHConnector:
             response.raise_for_status()
         return response.json()
 
+    
+    def get_product_category_details(self, product_details):
+        """
+        Get advanced details of the categories of a product
+        :param product_details: Product details object (dict) as returned by get_product_details or the taxonomy ID
+        :return: dict containing category information
+        """
+        if not isinstance(product_details, dict):
+            taxonomy_id = product_details
+        else:
+            taxonomy_id = product_details['productCard']['subCategoryId']
+        response = requests.get(
+            f'https://www.ah.nl/zoeken/api/products/taxonomy-brand?taxonomyId={taxonomy_id}'
+        )
+        if not response.ok:
+            response.raise_for_status()
+        return response.json()
+
     def get_bonus_periods(self):
         """
         Information about the current bonus periods active.

--- a/supermarktconnector/ah.py
+++ b/supermarktconnector/ah.py
@@ -10,6 +10,23 @@ HEADERS = {
     'content-type': 'application/json; charset=UTF-8',
 }
 
+HEADERS_WEB = {
+    'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.0.0 Safari/537.36 Edg/109.0.0.0',
+    'content-type': 'application/json',
+    'accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9',
+    'accept-encoding': 'gzip, deflate, br',
+    'accept-language': 'en-US,en;q=0.9,nl;q=0.8',
+    'dnt': '1',
+    'sec-fetch-dest': 'document',
+    'sec-fetch-mode': 'navigate',
+    'sec-fetch-site': 'none',
+    'sec-fetch-ua': '"Not_A Brand";v="99", "Microsoft Edge";v="109", "Chromium";v="109"',
+    'sec-fetch-ua-mobile': '?0',
+    'upgrade-insecure-requests': '1',
+    'sec-ch-ua-platform': '"Windows"',
+    'sec-fetch-user': '?1',
+}
+
 
 class AHConnector:
     @staticmethod
@@ -107,7 +124,7 @@ class AHConnector:
             brand = product_details['productCard']['brand']
         response = requests.get(
             'https://www.ah.nl/zoeken/api/products/taxonomy-brand?brand={}&taxonomyId={}'.format(brand, taxonomy_id),
-            headers={**HEADERS}
+            headers={**HEADERS_WEB}
         )
         if not response.ok:
             response.raise_for_status()


### PR DESCRIPTION
This pull requests adds the functionality to get more information about a product's categories.
For example, the [AH Mozzarella](https://www.ah.nl/producten/product/wi506235/ah-mozzarella) is under the categories (as seen at the top of the product page):
Kaas, vleeswaren, tapas > Kaas > Kaas voor borrel > Mozzarella, burrata > Mozzarella

With [get_product_details](https://github.com/bartmachielsen/SupermarktConnector/blob/master/supermarktconnector/ah.py#L61) we only get the main category and the subcategory, in our mozzarella example that would be "Kaas, vleeswaren, tapas" and "Mozzarella", respectively.

In general, what `get_product_category_details` returns is a list of products within the (sub)category of that product (or taxonomy, as they call it internally). In our example, our taxonomy is "Mozzarella", so the list that is returned by the method includes all mozzarella products (that have this taxonomy ID/are in the subcategory "Mozzarella").

Each product in the list includes some basic product information but most notably also all categories:
```python
{
"taxonomies": [{"id": 6402,
       "name": "Kaas, vleeswaren, tapas",
       "imageSiteTarget": "app_cat_kaas_vleeswaren_deli",
       "images": [],
       "shown": True,
       "level": 1,
       "sortSequence": 4,
       "parentIds": [0]},
      {"id": 1192,
       "name": "Kaas",
       "imageSiteTarget": "app_cat_kaas",
       "images": [],
       "shown": True,
       "level": 2,
       "sortSequence": 1,
       "parentIds": [6402]},
      {"id": 18539,
       "name": "Kaas voor borrel",
       "images": [],
       "shown": True,
       "level": 3,
       "sortSequence": 2,
       "parentIds": [1192]},
      {"id": 18567,
       "name": "Mozzarella, burrata",
       "images": [],
       "shown": True,
       "level": 4,
       "sortSequence": 9,
       "parentIds": [18539, 18541]},
      {"id": 4222,
       "name": "Mozzarella",
       "images": [],
       "shown": True,
       "level": 5,
       "sortSequence": 1,
       "parentIds": [18567]}]
}
```

The URL used is [https://www.ah.nl/zoeken/api/products/taxonomy-brand?taxonomyId={taxonomy_id}](https://www.ah.nl/zoeken/api/products/taxonomy-brand?taxonomyId={taxonomy_id}) and was taken directly from the search on the normal browser website. I did not find an endpoint for this on the mobile app.

The argument that the method takes is (a) the returned JSON from [get_product_details](https://github.com/bartmachielsen/SupermarktConnector/blob/master/supermarktconnector/ah.py#L61) or (b) the taxonomy ID itself. With (a), the taxonomy ID that will be passed over to the API is the ID of the lowest subcategory, so in our example it's "Mozzarella" with ID 4222. With (b), any category can be passed, so also "Kaas voor borrel" with ID 18539 and all products of that subcategory will be listed.