### PR TITLE
Update api version number

### DIFF
--- a/supermarktconnector/jumbo.py
+++ b/supermarktconnector/jumbo.py
@@ -11,7 +11,7 @@ HEADERS = {
 
 
 class JumboConnector:
-    jumbo_api_version = "v15"
+    jumbo_api_version = "v17"
 
     def search_products(self, query=None, page=0, size=30):
         if (page + 1 * size) > 30:


### PR DESCRIPTION
Someone has made an issue on this github that it doesn't work anymore. This is most definitely caused by the version number that can be easily updated.